### PR TITLE
typescript@3.0 updates

### DIFF
--- a/types/react/ts3.5/index.d.ts
+++ b/types/react/ts3.5/index.d.ts
@@ -442,8 +442,7 @@ declare namespace React {
          *
          * @see https://reactjs.org/docs/context.html
          */
-        // TODO (TypeScript 3.0): unknown
-        context: any;
+        context: unknown;
 
         constructor(props: Readonly<P>);
         /**
@@ -835,8 +834,7 @@ declare namespace React {
     // The identity check is done with the SameValue algorithm (Object.is), which is stricter than ===
     type ReducerStateWithoutAction<R extends ReducerWithoutAction<any>> =
         R extends ReducerWithoutAction<infer S> ? S : never;
-    // TODO (TypeScript 3.0): ReadonlyArray<unknown>
-    type DependencyList = ReadonlyArray<any>;
+    type DependencyList = ReadonlyArray<unknown>;
 
     // NOTE: callbacks are _only_ allowed to return either void, or a destructor.
     // The destructor is itself only allowed to return void.
@@ -971,8 +969,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    // TODO (TypeScript 3.0): <T extends unknown>
-    function useRef<T>(initialValue: T): MutableRefObject<T>;
+    function useRef<T extends unknown>(initialValue: T): MutableRefObject<T>;
     // convenience overload for refs given as a ref prop as they typically start with a null value
     /**
      * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
@@ -987,8 +984,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    // TODO (TypeScript 3.0): <T extends unknown>
-    function useRef<T>(initialValue: T|null): RefObject<T>;
+    function useRef<T extends unknown>(initialValue: T | null): RefObject<T>;
     // convenience overload for potentially undefined initialValue / call with 0 arguments
     // has a default to stop it from defaulting to {} instead
     /**
@@ -1001,8 +997,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#useref
      */
-    // TODO (TypeScript 3.0): <T extends unknown>
-    function useRef<T = undefined>(): MutableRefObject<T | undefined>;
+    function useRef<T extends unknown>(): MutableRefObject<T | undefined>;
     /**
      * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
      * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside
@@ -1047,8 +1042,7 @@ declare namespace React {
      * @version 16.8.0
      * @see https://reactjs.org/docs/hooks-reference.html#usecallback
      */
-    // TODO (TypeScript 3.0): <T extends (...args: never[]) => unknown>
-    function useCallback<T extends (...args: any[]) => any>(callback: T, deps: DependencyList): T;
+    function useCallback<T extends (...args: never[]) => unknown>(callback: T, deps: DependencyList): T;
     /**
      * `useMemo` will only recompute the memoized value when one of the `deps` has changed.
      *

--- a/types/react/ts3.5/test/hooks.tsx
+++ b/types/react/ts3.5/test/hooks.tsx
@@ -91,11 +91,7 @@ const context = React.createContext<Context>({ test: true });
 function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     const value: Context = React.useContext(context);
     const [, setState] = React.useState(() => 0);
-    // Bonus typescript@next version
-    // const [reducerState, dispatch] = React.useReducer(reducer, true as const, arg => arg && initialState);
-    // Compile error in typescript@3.0 but not in typescript@3.1.
-    // const [reducerState, dispatch] = React.useReducer(reducer, true as true, arg => arg && initialState);
-    const [reducerState, dispatch] = React.useReducer(reducer, true as true, (arg: true): AppState => arg && initialState);
+    const [reducerState, dispatch] = React.useReducer(reducer, true as const, arg => arg && initialState);
 
     const [, simpleDispatch] = React.useReducer(v => v + 1, 0);
 
@@ -123,7 +119,7 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
 
     // |undefined convenience overload
     // with no contextual type or generic argument it should default to undefined only (not {} or unknown!)
-    // $ExpectType MutableRefObject<undefined>
+    // $ExpectType MutableRefObject<unknown>
     React.useRef();
     // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number>();
@@ -230,5 +226,5 @@ const UsesEveryHook = React.forwardRef(
 const everyHookRef = React.createRef<{ id: number }>();
 <UsesEveryHook ref={everyHookRef}/>;
 
-// TODO: "implicit any" in typescript@3.0 but not in typescript@3.1
-// <UsesEveryHook ref={ref => { ref && console.log(ref.id); }}/>;
+const constVoid = (a: any): void => {};
+<UsesEveryHook ref={ref => { ref && constVoid(ref.id); }}/>;

--- a/types/react/ts3.5/test/index.ts
+++ b/types/react/ts3.5/test/index.ts
@@ -823,9 +823,8 @@ React.createElement(Memoized2, { bar: 'string' });
 const specialSfc1: React.ExoticComponent<any> = Memoized1;
 const functionComponent: React.FunctionComponent<any> = Memoized2;
 const sfc: React.SFC<any> = Memoized2;
-// this $ExpectError is failing on TypeScript@next
-// // $ExpectError Property '$$typeof' is missing in type
-// const specialSfc2: React.SpecialSFC = props => null;
+// $ExpectError Property '$$typeof' is missing in type
+const specialSfc2: React.SFC = props => null;
 
 const propsWithChildren: React.PropsWithChildren<Props> = {
     hello: "world",

--- a/types/react/ts3.5/test/managedAttributes.tsx
+++ b/types/react/ts3.5/test/managedAttributes.tsx
@@ -1,201 +1,200 @@
-interface LeaveMeAloneDtslint { foo: string; }
-// // Re-enable when we move @types/react to TS 3.0
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
 
-// import * as React from 'react';
-// import * as PropTypes from 'prop-types';
+interface Props {
+    bool?: boolean;
+    fnc: () => any;
+    node?: React.ReactNode;
+    num?: number;
+    reqNode: NonNullable<React.ReactNode>;
+    str: string;
+}
 
-// interface Props {
-//     bool?: boolean;
-//     fnc: () => any;
-//     node?: React.ReactNode;
-//     num?: number;
-//     reqNode: NonNullable<React.ReactNode>;
-//     str: string;
-// }
+const propTypes = {
+    bool: PropTypes.bool,
+    fnc: PropTypes.func.isRequired,
+    node: PropTypes.node,
+    num: PropTypes.number,
+    str: PropTypes.string.isRequired,
+    extraStr: PropTypes.string.isRequired,
+    extraNum: PropTypes.number
+};
 
-// const propTypes = {
-//     bool: PropTypes.bool,
-//     fnc: PropTypes.func.isRequired,
-//     node: PropTypes.node,
-//     num: PropTypes.number,
-//     str: PropTypes.string.isRequired,
-//     extraStr: PropTypes.string.isRequired,
-//     extraNum: PropTypes.number
-// };
+const defaultProps = {
+    fnc: (() => 'abc') as () => any,
+    extraBool: false,
+    reqNode: 'text_node' as NonNullable<React.ReactNode>
+};
 
-// const defaultProps = {
-//     fnc: (() => 'abc') as () => any,
-//     extraBool: false,
-//     reqNode: 'text_node' as NonNullable<React.ReactNode>
-// };
+class AnnotatedPropTypesAndDefaultProps extends React.Component<Props> {
+    static propTypes = propTypes;
+    static defaultProps = defaultProps;
+}
 
-// class AnnotatedPropTypesAndDefaultProps extends React.Component<Props> {
-//     static propTypes = propTypes;
-//     static defaultProps = defaultProps;
-// }
+const constFn = () => "foo";
 
-// const annotatedPropTypesAndDefaultPropsTests = [
-//     // $ExpectError
-//     <AnnotatedPropTypesAndDefaultProps />, // str and extraStr are required
-//     <AnnotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-//     // $ExpectError
-//     <AnnotatedPropTypesAndDefaultProps num='abc' />, // num type mismatch
-//     <AnnotatedPropTypesAndDefaultProps
-//         bool={true}
-//         extraBool={true}
-//         extraNum={0}
-//         extraStr='abc'
-//         fnc={console.log}
-//         node={<span />}
-//         num={0}
-//         reqNode={<span />}
-//         str='abc'
-//     />
-// ];
+const annotatedPropTypesAndDefaultPropsTests = [
+    // $ExpectError
+    <AnnotatedPropTypesAndDefaultProps />, // str and extraStr are required
+    <AnnotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
+    // $ExpectError
+    <AnnotatedPropTypesAndDefaultProps num='abc' />, // num type mismatch
+    <AnnotatedPropTypesAndDefaultProps
+        bool={true}
+        extraBool={true}
+        extraNum={0}
+        extraStr='abc'
+        fnc={() => "foo"}
+        node={<span />}
+        num={0}
+        reqNode={<span />}
+        str='abc'
+    />
+];
 
-// class UnannotatedPropTypesAndDefaultProps extends React.Component {
-//     static propTypes = propTypes;
-//     static defaultProps = defaultProps;
-// }
+class UnannotatedPropTypesAndDefaultProps extends React.Component {
+    static propTypes = propTypes;
+    static defaultProps = defaultProps;
+}
 
-// const unannotatedPropTypesAndDefaultPropsTests = [
-//     // $ExpectError
-//     <UnannotatedPropTypesAndDefaultProps />, // stra and extraStr are required
-//     <UnannotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-//     // $ExpectError
-//     <UnannotatedPropTypesAndDefaultProps extraBool={0} />, // extraBool type mismatch
-//     <UnannotatedPropTypesAndDefaultProps
-//         bool={true}
-//         extraBool={true}
-//         extraNum={0}
-//         extraStr='abc'
-//         fnc={console.log}
-//         node={<span />}
-//         num={0}
-//         reqNode={<span />}
-//         str='abc'
-//     />
-// ];
+const unannotatedPropTypesAndDefaultPropsTests = [
+    // $ExpectError
+    <UnannotatedPropTypesAndDefaultProps />, // stra and extraStr are required
+    <UnannotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
+    // $ExpectError
+    <UnannotatedPropTypesAndDefaultProps extraBool={0} />, // extraBool type mismatch
+    <UnannotatedPropTypesAndDefaultProps
+        bool={true}
+        extraBool={true}
+        extraNum={0}
+        extraStr='abc'
+        fnc={constFn}
+        node={<span />}
+        num={0}
+        reqNode={<span />}
+        str='abc'
+    />
+];
 
-// class AnnotatedPropTypes extends React.Component<Props> {
-//     static propTypes = propTypes;
-// }
+class AnnotatedPropTypes extends React.Component<Props> {
+    static propTypes = propTypes;
+}
 
-// const annotatedPropTypesTests = [
-//     // $ExpectError
-//     <AnnotatedPropTypes />, // str, extraStr, reqNode and fnc are required
-//     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />,
-//     // $ExpectError
-//     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
-//     // $ExpectError
-//     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
-//     <AnnotatedPropTypes
-//         bool={false}
-//         extraNum={0}
-//         extraStr='abc'
-//         fnc={console.log}
-//         node={<React.Fragment />}
-//         num={0}
-//         reqNode={<React.Fragment />}
-//         str='abc'
-//     />
-// ];
+const annotatedPropTypesTests = [
+    // $ExpectError
+    <AnnotatedPropTypes />, // str, extraStr, reqNode and fnc are required
+    <AnnotatedPropTypes fnc={constFn} extraStr='abc' str='abc' reqNode={<span />} />,
+    // $ExpectError
+    <AnnotatedPropTypes fnc={constFn} extraStr='abc' str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
+    // $ExpectError
+    <AnnotatedPropTypes fnc={constFn} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
+    <AnnotatedPropTypes
+        bool={false}
+        extraNum={0}
+        extraStr='abc'
+        fnc={constFn}
+        node={<React.Fragment />}
+        num={0}
+        reqNode={<React.Fragment />}
+        str='abc'
+    />
+];
 
-// class UnannotatedPropTypes extends React.Component {
-//     static propTypes = propTypes;
-// }
+class UnannotatedPropTypes extends React.Component {
+    static propTypes = propTypes;
+}
 
-// const unannotatedPropTypesTests = [
-//     // $ExpectError
-//     <UnannotatedPropTypes />, // str, extraStr and fnc are required
-//     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' />,
-//     // $ExpectError
-//     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />, // reqNode doesn't exist
-//     // $ExpectError
-//     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
-//     <UnannotatedPropTypes
-//         bool={false}
-//         extraNum={0}
-//         extraStr='abc'
-//         fnc={console.log}
-//         node={<React.Fragment />}
-//         num={0}
-//         str='abc'
-//     />
-// ];
+const unannotatedPropTypesTests = [
+    // $ExpectError
+    <UnannotatedPropTypes />, // str, extraStr and fnc are required
+    <UnannotatedPropTypes fnc={constFn} extraStr='abc' str='abc' />,
+    // $ExpectError
+    <UnannotatedPropTypes fnc={constFn} extraStr='abc' str='abc' reqNode={<span />} />, // reqNode doesn't exist
+    // $ExpectError
+    <UnannotatedPropTypes fnc={constFn} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
+    <UnannotatedPropTypes
+        bool={false}
+        extraNum={0}
+        extraStr='abc'
+        fnc={constFn}
+        node={<React.Fragment />}
+        num={0}
+        str='abc'
+    />
+];
 
-// class AnnotatedDefaultProps extends React.Component<Props> {
-//     static defaultProps = defaultProps;
-// }
+class AnnotatedDefaultProps extends React.Component<Props> {
+    static defaultProps = defaultProps;
+}
 
-// const annotatedDefaultPropsTests = [
-//     // $ExpectError
-//     <AnnotatedDefaultProps />, // str is required
-//     <AnnotatedDefaultProps str='abc' />,
-//     <AnnotatedDefaultProps str='abc' reqNode={<span />} />,
-//     // $ExpectError
-//     <AnnotatedDefaultProps str={() => { }} />, // str type mismatch
-//     <AnnotatedDefaultProps
-//         bool={true}
-//         extraBool={false}
-//         fnc={console.log}
-//         node={null}
-//         num={0}
-//         reqNode={undefined}
-//         str='abc'
-//     />
-// ];
+const annotatedDefaultPropsTests = [
+    // $ExpectError
+    <AnnotatedDefaultProps />, // str is required
+    <AnnotatedDefaultProps str='abc' />,
+    <AnnotatedDefaultProps str='abc' reqNode={<span />} />,
+    // $ExpectError
+    <AnnotatedDefaultProps str={() => { }} />, // str type mismatch
+    <AnnotatedDefaultProps
+        bool={true}
+        extraBool={false}
+        fnc={constFn}
+        node={null}
+        num={0}
+        reqNode={undefined}
+        str='abc'
+    />
+];
 
-// class UnannotatedDefaultProps extends React.Component {
-//     static defaultProps = defaultProps;
-// }
+class UnannotatedDefaultProps extends React.Component {
+    static defaultProps = defaultProps;
+}
 
-// const unannotatedDefaultPropsTests = [
-//     <UnannotatedDefaultProps />,
-//     <UnannotatedDefaultProps
-//         extraBool={true}
-//         fnc={console.log}
-//         reqNode={<span />}
-//     />
-// ];
+const unannotatedDefaultPropsTests = [
+    <UnannotatedDefaultProps />,
+    <UnannotatedDefaultProps
+        extraBool={true}
+        fnc={constFn}
+        reqNode={<span />}
+    />
+];
 
-// class ComponentWithNoDefaultProps extends React.Component<Props> {}
+class ComponentWithNoDefaultProps extends React.Component<Props> {}
 
-// function FunctionalComponent(props: Props) { return <>{props.reqNode}</> }
-// FunctionalComponent.defaultProps = defaultProps;
+function FunctionalComponent(props: Props) { return (<>{props.reqNode}</>); }
+FunctionalComponent.defaultProps = defaultProps;
 
-// const functionalComponentTests = [
-//     // $ExpectError
-//     <FunctionalComponent />,
-//     // This is possibly a bug/limitation of TS
-//     // Even if JSX.LibraryManagedAttributes returns the correct type, it doesn't seem to work with non-classes
-//     // This also doesn't work with things typed React.SFC<P> because defaultProps will always be Partial<P>
-//     // $ExpectError
-//     <FunctionalComponent str='' />
-// ];
+const functionalComponentTests = [
+    // $ExpectError
+    <FunctionalComponent />,
+    // This is possibly a bug/limitation of TS
+    // Even if JSX.LibraryManagedAttributes returns the correct type, it doesn't seem to work with non-classes
+    // This also doesn't work with things typed React.SFC<P> because defaultProps will always be Partial<P>
+    // // $ExpectError
+    // <FunctionalComponent str='' />
+];
 
-// const MemoFunctionalComponent = React.memo(FunctionalComponent);
-// const MemoAnnotatedDefaultProps = React.memo(AnnotatedDefaultProps);
-// const LazyMemoFunctionalComponent = React.lazy(async () => ({ default: MemoFunctionalComponent }));
-// const LazyMemoAnnotatedDefaultProps = React.lazy(async () => ({ default: MemoAnnotatedDefaultProps }));
+const MemoFunctionalComponent = React.memo(FunctionalComponent);
+const MemoAnnotatedDefaultProps = React.memo(AnnotatedDefaultProps);
+const LazyMemoFunctionalComponent = React.lazy(async () => ({ default: MemoFunctionalComponent }));
+const LazyMemoAnnotatedDefaultProps = React.lazy(async () => ({ default: MemoAnnotatedDefaultProps }));
 
-// const memoTests = [
-//     // $ExpectError
-//     <MemoFunctionalComponent />,
-//     // $ExpectError won't work as long as FunctionalComponent doesn't work either
-//     <MemoFunctionalComponent str='abc' />,
-//     // $ExpectError
-//     <MemoAnnotatedDefaultProps />,
-//     <AnnotatedDefaultProps str='abc' />,
-//     // $ExpectError this doesn't work despite JSX.LibraryManagedAttributes returning the correct type
-//     <MemoAnnotatedDefaultProps str='abc' />,
-//     // $ExpectError won't work as long as FunctionalComponent doesn't work either
-//     <LazyMemoFunctionalComponent str='abc' />,
-//     // $ExpectError
-//     <LazyMemoAnnotatedDefaultProps />,
-//     // $ExpectError this doesn't work despite JSX.LibraryManagedAttributes returning the correct type
-//     <LazyMemoAnnotatedDefaultProps str='abc' />
-// ];
+const memoTests = [
+    // $ExpectError
+    <MemoFunctionalComponent />,
+    // $ExpectError won't work as long as FunctionalComponent doesn't work either
+    <MemoFunctionalComponent str='abc' />,
+    // $ExpectError
+    <MemoAnnotatedDefaultProps />,
+    <AnnotatedDefaultProps str='abc' />,
+    // $ExpectError this doesn't work despite JSX.LibraryManagedAttributes returning the correct type
+    <MemoAnnotatedDefaultProps str='abc' />,
+    // $ExpectError won't work as long as FunctionalComponent doesn't work either
+    <LazyMemoFunctionalComponent str='abc' />,
+    // $ExpectError
+    <LazyMemoAnnotatedDefaultProps />,
+    // $ExpectError this doesn't work despite JSX.LibraryManagedAttributes returning the correct type
+    <LazyMemoAnnotatedDefaultProps str='abc' />
+];
 
 // type AnnotatedDefaultPropsLibraryManagedAttributes = JSX.LibraryManagedAttributes<typeof AnnotatedDefaultProps, Props>;
 // // $ExpectType AnnotatedDefaultPropsLibraryManagedAttributes
@@ -205,72 +204,72 @@ interface LeaveMeAloneDtslint { foo: string; }
 // // $ExpectType FunctionalComponentLibraryManagedAttributes
 // type LazyMemoFunctionalComponentLibraryManagedAttributes = JSX.LibraryManagedAttributes<typeof LazyMemoFunctionalComponent, Props>;
 
-// const ForwardRef = React.forwardRef((props: Props, ref: React.Ref<ComponentWithNoDefaultProps>) => (
-//     <ComponentWithNoDefaultProps ref={ref} {...props}/>
-// ));
-// ForwardRef.defaultProps = defaultProps;
+const ForwardRef = React.forwardRef((props: Props, ref: React.Ref<ComponentWithNoDefaultProps>) => (
+    <ComponentWithNoDefaultProps ref={ref} {...props}/>
+));
+ForwardRef.defaultProps = defaultProps;
 
-// const forwardRefTests = [
-//     // $ExpectError
-//     <ForwardRef />,
-//     <ForwardRef
-//         fnc={console.log}
-//         reqNode={<span />}
-//         str=''
-//     />,
-//     // same bug as MemoFunctionalComponent and React.SFC-typed things
-//     // $ExpectError the type of ForwardRef.defaultProps stays Partial<P> anyway even if assigned
-//     <ForwardRef str='abc' />
-// ];
+const forwardRefTests = [
+    // $ExpectError
+    <ForwardRef />,
+    <ForwardRef
+        fnc={constFn}
+        reqNode={<span />}
+        str=''
+    />,
+    // same bug as MemoFunctionalComponent and React.SFC-typed things
+    // $ExpectError the type of ForwardRef.defaultProps stays Partial<P> anyway even if assigned
+    // <ForwardRef str='abc' />
+];
 
-// const weakComponentPropTypes = {
-//     foo: PropTypes.string,
-//     bar: PropTypes.bool.isRequired
-// };
-// interface WeakComponentProps1 {
-//     foo: any;
-//     bar: number;
-// }
-// interface WeakComponentProps2 {
-//     foo: string;
-//     bar: any;
-// }
-// interface WeakComponentProps3 {
-//     foo: any;
-//     bar: any;
-// }
+const weakComponentPropTypes = {
+    foo: PropTypes.string,
+    bar: PropTypes.bool.isRequired
+};
+interface WeakComponentProps1 {
+    foo: any;
+    bar: number;
+}
+interface WeakComponentProps2 {
+    foo: string;
+    bar: any;
+}
+interface WeakComponentProps3 {
+    foo: any;
+    bar: any;
+}
 
-// // $ExpectType true
-// type weakComponentTest1 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, any> extends {
-//     foo?: string | null
-//     bar: boolean
-// } ? true : false;
-// // $ExpectType true
-// type weakComponentTest2 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps1> extends {
-//     foo?: string | null
-//     bar: number
-// } ? true : false;
-// // $ExpectType true
-// type weakComponentTest3 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps2> extends {
-//     foo: string
-//     bar: boolean
-// } ? true : false;
+// $ExpectType true
+type weakComponentTest1 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, any> extends {
+    foo?: string | null
+    bar: boolean
+} ? true : false;
+// $ExpectType true
+type weakComponentTest2 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps1> extends {
+    foo?: string | null
+    bar: number
+} ? true : false;
+// $ExpectType true
+type weakComponentTest3 = JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps2> extends {
+    foo: string
+    bar: boolean
+} ? true : false;
 
-// // $ExpectError
-// const weakComponentOptionalityTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { foo: '' };
-// const weakComponentOptionalityTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { bar: true };
+// $ExpectError
+const weakComponentOptionalityTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { foo: '' };
+const weakComponentOptionalityTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakComponentProps3> = { bar: true };
 
-// interface IndexedComponentProps {
-//     [K: string]: boolean;
-// }
-// interface WeakIndexedComponentProps {
-//     [K: string]: any;
-// }
+interface IndexedComponentProps {
+    [K: string]: boolean;
+}
+interface WeakIndexedComponentProps {
+    [K: string]: any;
+}
 
-// const weakComponentIndexedTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { };
-// // $ExpectError
-// const weakComponentIndexedTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { foo: '' };
-// const weakComponentIndexedTest3: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: '' };
-// const weakComponentIndexedTest4: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: 4 };
+const weakComponentIndexedTest1: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { };
+// $ExpectError
+const weakComponentIndexedTest2: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, IndexedComponentProps> = { foo: '' };
+const weakComponentIndexedTest3: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: '' };
+const weakComponentIndexedTest4: JSX.LibraryManagedAttributes<{ propTypes: typeof weakComponentPropTypes }, WeakIndexedComponentProps> = { foo: 4 };
 
-// const optionalUnionPropTest: JSX.LibraryManagedAttributes<{ propTypes: {} }, { optional?: string } | { optional?: number }> = {};
+const optionalUnionPropTest: JSX.LibraryManagedAttributes<{ propTypes: {} }, { optional?: string } | { optional?: number }> = {};

--- a/types/react/ts3.5/test/tsx.tsx
+++ b/types/react/ts3.5/test/tsx.tsx
@@ -234,17 +234,15 @@ const Memoized6: React.NamedExoticComponent<object> = React.memo(props => null);
 // $ExpectError
 <Memoized6 foo/>;
 
-// NOTE: this test _requires_ TypeScript 3.1
-// It is passing, for what it's worth.
-// const Memoized7 = React.memo((() => {
-//     function HasDefaultProps(props: { test: boolean }) { return null; }
-//     HasDefaultProps.defaultProps = {
-//         test: true
-//     };
-//     return HasDefaultProps;
-// })());
-// // $ExpectType boolean
-// Memoized7.type.defaultProps.test;
+const Memoized7 = React.memo((() => {
+    function HasDefaultProps(props: { test: boolean }) { return null; }
+    HasDefaultProps.defaultProps = {
+        test: true
+    };
+    return HasDefaultProps;
+})());
+// $ExpectType boolean
+Memoized7.type.defaultProps.test;
 
 const LazyClassComponent = React.lazy(async () => ({ default: ComponentWithPropsAndState }));
 const LazyMemoized3 = React.lazy(async () => ({ default: Memoized3 }));
@@ -261,13 +259,21 @@ const LazyRefForwarding = React.lazy(async () => ({ default: Memoized4 }));
 // $ExpectError
 <React.Suspense/>;
 
+function isFoo(a: unknown): a is {foo: PropTypes.Validator<NonNullable<PropTypes.ReactNodeLike>>} {
+    return typeof a === "object" && a !== null && a.hasOwnProperty("foo");
+}
+
 class LegacyContext extends React.Component {
-    static contextTypes = { foo: PropTypes.node.isRequired };
+    static contextTypes: { foo: PropTypes.Validator<NonNullable<PropTypes.ReactNodeLike>> } = { foo: PropTypes.node.isRequired };
 
     render() {
-        // $ExpectType any
-        this.context.foo;
-        return this.context.foo;
+        // $ExpectType unknown
+        this.context;
+
+        if (isFoo(this.context)) {
+            // $ExpectTpe PropTypes.Validator<NonNullable<PropTypes.ReactNodeLike>>
+            return this.context.foo;
+        }
     }
 }
 


### PR DESCRIPTION
Updates types and tests to support `unknown` property in typescript@3.0. Additionally enables commented out tests intended for typescript@3.0 

Addresses #3 